### PR TITLE
report terminal size so rlwrap repls will work

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
 	"syscall"
 
@@ -47,8 +48,24 @@ func spawn(command string, args []string) {
 	}
 	defer func() { _ = term.Restore(int(os.Stdin.Fd()), oldState) }()
 
+	// Get current terminal size
+	width, height, err := term.GetSize(int(os.Stdin.Fd()))
+	if err != nil {
+		// Fallback to reasonable defaults if we can't get terminal size
+		width, height = 80, 24
+	}
+
 	cmd := exec.Command(command, args...)
-	ptmx, err := pty.Start(cmd)
+	
+	// Create PTY with proper terminal dimensions
+	winsize := &pty.Winsize{
+		Rows: uint16(height),
+		Cols: uint16(width),
+		X:    0,
+		Y:    0,
+	}
+	
+	ptmx, err := pty.StartWithSize(cmd, winsize)
 	processError(err)
 	defer func() { _ = ptmx.Close() }()
 
@@ -57,6 +74,17 @@ func spawn(command string, args []string) {
 	defer pipe.Close()
 
 	pipeReader := bufio.NewReader(pipe)
+
+	// Handle terminal resize signals
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGWINCH)
+	go func() {
+		for range ch {
+			if err := pty.InheritSize(os.Stdin, ptmx); err != nil {
+				log.Printf("error resizing pty: %s", err)
+			}
+		}
+	}()
 
 	go func() {
 		_, err = io.Copy(os.Stdout, ptmx)


### PR DESCRIPTION
# Problem

When using `reple spawn` with commands that use `rlwrap` (like `clj`), the command would fail with:

```
rlwrap: error: My terminal reports width=0 (is it emacs?) I can't handle this, sorry!`
```

This occurred because the PTY was created without proper terminal dimensions, causing `rlwrap` to detect a width of 0.

# Solution

- Use `pty.StartWithSize()` instead of `pty.Start()` to create the PTY with proper terminal dimensions
- Detect current terminal size using `term.GetSize()` with fallback to 80x24 defaults
- Add `SIGWINCH` signal handling to dynamically resize the PTY when the terminal window is resized

The fix enables `rlwrap`-based commands like `clj` to work properly with `reple`, providing cursor history navigation and other `readline` features.